### PR TITLE
Feature: Support `transactionalBatch`;

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,12 @@
+# idb-batch
+
+## ?
+
+* Feature: Support `transactionalBatch`
+* Feature: Added `getStoreNames`
+* Feature: Allow preexisting transaction to be supplied to `batch()` (or `transactionalBatch()`)
+* Feature: Support `move`, `copy` operations
+
 ## 1.0.0 / 2015-12-06
 
 * initial release :sparkles:

--- a/Readme.md
+++ b/Readme.md
@@ -42,14 +42,96 @@ function upgradeCallback(e) {
 }
 ```
 
-### batch(db: IDBDatabase, storeName: String, ops: Array|Object)
+### transactionalBatch(tr: IDBDatabase|IDBTransaction, storeOpsArr, opts = { parallel: false, extraStores: [], resolveEarly: false })
 
-This creates a `readwrite` transaction to `storeName`,
-and performs `ops` sequentially. It returns a `Promise` which resolves with the results of each request.
+`transactionalBatch` allows you to make operations across multiple stores
+within a single transaction.
+
+You may pass in your own `IDBTransaction` as `tr` or just supply an
+`IDBDatabase` object and let `transactionalBatch` iterate over your operations
+to determine what store names should be part of the transaction.
+
+`storeOpsArr` is an array whose items are either functions (which accept the
+transaction shared by the batch as argument) or objects whose keys are store
+names and whose values follow the Array or Object notation described under
+the `ops` argument of `batch`. `storeOpsArr` can also be such a single object
+keyed by store name (its results will be presented in the resolved Promise
+as if the object had been supplied within a (single-item) array).
+
+If you are using store-name-keyed objects within `storeOpsArr`, be aware
+that iteration order may not be consistent within an object, even when
+`parallel` is false (see below), so you may wish to limit yourself to one
+store key per object and use more objects.
+
+`transactionalBatch` returns a `Promise` which resolves with the results of
+each request. The results will be an array containing a child array for each
+child of `storeOpsArr`. Within those child arrays will be, when functions are
+supplied, the return result or, when objects are supplied, an object whose
+keys are store names and whose values are the array of results for each child
+operation.
+
+#### `transactionalBatch` option: `extraStores`: Array
+
+If you are using functions which operate on store names not specified elsewhere
+among the (Object-based) operations, you may add those store names to the
+`extraStores` property to allow the transaction shared with the functions to
+operate on those store names.
+
+#### `transactionalBatch` option: `parallel`: Boolean
+
+The default behavior is to conduct operations in series, waiting for each
+operation to complete before proceeding to the next (including waiting for
+promises to resolve if a function-based operation supplies them as its own
+return value, noting however that there is some risk in doing so, especially
+when chaining promises, in that the transaction of the batch may actually
+complete (and its promise thus resolve) before the operation's promise
+resolves). If your batch of operations does not need to occur in order,
+you may instead set the `parallel` option to `true` which will load operations
+in parallel, and will not wait for operations to complete before proceeding
+to the next, nor will it wait for all operations pertaining to a given store
+or function to complete before proceeding to the next set of operations.
+
+#### `transactionalBatch` option: `resolveEarly`: Boolean
+
+By default, the promise returned by `transactionalBatch` will only resolve
+with its array of results collecting return values for each of the
+operations will only be made available after the transaction completes.
+Setting `resolveEarly` to `true` will allow the promise to resolve with
+the results array before it may be fully populated but after it has begun
+execution of all of the operations within the batch.
+
+#### `transactionalBatch` option: `adapterCb`: Function
+
+By default, any function-type operations will be supplied the transaction
+and the return result will be added to the results.
+
+`adapterCb` is an optional callback which will be supplied the transaction
+as well as the currently iterated function-type operation. The return
+result of this callback will be added to the results. This allows for
+supplying additional or alternative arguments to the callback (as opposed to
+just the transaction object).
+
+### batch(db: IDBDatabase|IDBTransaction, storeName: String, ops: Array|Object, opts: { parallel: false, extraStores: [], resolveEarly: false })
+
+This creates a `readwrite` transaction to `storeName`, and performs `ops`
+sequentially. It returns a `Promise` which resolves with the results of
+each request.
+
+This function only operates on a single store; if you require operations across
+multiple stores, use `transactionalBatch`. See `transactionalBatch` also for
+a description of the properties that may be used on `opts`.
+
+Although this function allows an `IDBTransaction` in place of `IDBDatabase`,
+usually, it may be generally more convenient to just pass in `IDBDatabase` and
+let `batch` build the transaction for you (by auto-detecting the store names
+implicit in `ops`).
 
 **Array notation** is inspired by [LevelUP](https://github.com/Level/levelup#batch).
 Each operation is an object with 3 possible properties: `type`, `key`, `value`.
-`type` is either `add`, `put`, or `del`, and `key` is optional (when the store has a `keyPath` and the supplied value contains it).
+`type` is either `add`, `put`, `del`, `move`, `copy`, or `clear`, and `key` is
+optional when the store has a `keyPath` and the supplied value contains it.
+When `move` or `copy` is used, the `key` represents the new destination of
+the operation and `value` represents the old key from which to move or copy.
 
 ```js
 await batch(db, 'books', [
@@ -59,8 +141,18 @@ await batch(db, 'books', [
 ])
 ```
 
-**Object notation** is sugar on top of array notation for `put`/`del` operations.
-Set `key` to `null` in order to delete a value.
+Note that `move` is composed of two operations, `copy` and `del`, and, at
+present, does not function atomically, so if you set `parallel` to `true`,
+there is a small chance that subsequent operations could occur after the
+`copy` but before the `del` takes place (though the deleting will not take
+place until a copy has been made).
+
+At present, there are no options to allow `copy` or `move` to work across
+stores or to involve sub-objects. You should instead use functions to conduct
+such operations.
+
+**Object notation** is sugar on top of array notation for `put`/`del`
+operations. Set `key` to `null` in order to delete a value.
 
 ```js
 await batch(db, 'storage', {
@@ -70,12 +162,21 @@ await batch(db, 'storage', {
 })
 ```
 
+### getStoreNames(storeOps: Array|Object)
+
+Returns an array of the store names used in a set of store operations.
+This function does not obtain store names used solely within function
+operations. If you wish for a function operation to operate on additional
+store names and as part of the same transaction, you should add the required
+store names to the `extraStores` option of `transactionalBatch`.
+
 ### ConstraintError
 
-If during sequential execution one of the operations throws a `ConstraintError`,
-the `Promise` rejects with an error, but previous successful operations will commit.
-This behavior may change in future versions,
-as I figure out how to properly abort transactions in IndexedDBShim.
+If during sequential execution one of the operations throws a
+`ConstraintError`, the `Promise` rejects with an error, but previous
+successful operations will commit.
+This behavior may change in future versions, as I figure out how to
+properly abort transactions in `IndexedDBShim`.
 
 ## LICENSE
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-eslint": "^5.0.0-beta4",
     "babel-plugin-add-module-exports": "^0.1.1",
     "babel-plugin-transform-async-to-generator": "^6.3.13",
+    "babel-polyfill": "^6.8.0",
     "babel-preset-es2015": "^6.3.13",
     "babelify": "^7.2.0",
     "browserify-test": "^2.1.2",
@@ -43,7 +44,7 @@
     "idb-schema": "^3.2.1",
     "indexeddbshim": "^2.2.1",
     "polyfill-function-prototype-bind": "0.0.1",
-    "regenerator": "^0.8.42",
+    "regenerator-runtime-only": "^0.8.38",
     "zuul": "^3.8.0"
   }
 }


### PR DESCRIPTION
Addresses #1 and #2

Feature: Support `transactionalBatch`; 
Feature: Allow preexisting transaction to be supplied to `batch()` (or `transactionalBatch()`);
Feature: Support `move`, `copy` operations;
Testing: Fix test name/db; add 'clear' test
Imports: Avoid deprecation notice for regenerator;
Refactoring: Add babel-polyfill for iterators;
Refactoring: Use increment/decrement operators, avoid redundant Boolean cast;
Refactoring: For transaction, use `addEventListener` in place of on\* handlers (may be reused, e.g., by function-type operations)
